### PR TITLE
Potential fix for code scanning alert no. 33: Server-side request forgery

### DIFF
--- a/backend/services/PiHoleWebService.js
+++ b/backend/services/PiHoleWebService.js
@@ -6,14 +6,51 @@ class PiHoleWebService {
     this.logger = logger;
   }
 
-  createApiClient(host, port = 80, useHttps = false) {
-    // Handle full URLs (e.g., "https://your-pihole-domain.com/admin")
-    let baseURL;
-    if (host.startsWith('http://') || host.startsWith('https://')) {
-      baseURL = host;
-    } else {
-      baseURL = `${useHttps ? 'https' : 'http'}://${host}${port !== (useHttps ? 443 : 80) ? ':' + port : ''}`;
+  /**
+   * Sanitize and validate a user-supplied host value to mitigate SSRF.
+   * Accepts only a bare hostname or IP address (no scheme, path, query, or fragment).
+   * Throws an error if the host is invalid.
+   */
+  sanitizeHost(host) {
+    if (typeof host !== 'string') {
+      throw new Error('Invalid host: host must be a string');
     }
+
+    let sanitized = host.trim();
+
+    // Strip protocol if present, but do not allow embedded paths after it.
+    if (sanitized.startsWith('http://')) {
+      sanitized = sanitized.substring('http://'.length);
+    } else if (sanitized.startsWith('https://')) {
+      sanitized = sanitized.substring('https://'.length);
+    }
+
+    // Reject anything that contains a path, query, or fragment.
+    if (sanitized.includes('/') || sanitized.includes('\\') || sanitized.includes('?') || sanitized.includes('#')) {
+      throw new Error('Invalid host: must not contain path, query, or fragment');
+    }
+
+    // Basic character whitelist: hostname / IPv4 / (simple) IPv6 literals.
+    // Allows letters, digits, dots, hyphens, colons and square brackets for IPv6.
+    const hostPattern = /^[A-Za-z0-9.\-:\[\]]+$/;
+    if (!hostPattern.test(sanitized)) {
+      throw new Error('Invalid host: contains disallowed characters');
+    }
+
+    if (sanitized.length === 0) {
+      throw new Error('Invalid host: empty value');
+    }
+
+    return sanitized;
+  }
+
+  createApiClient(host, port = 80, useHttps = false) {
+    // Sanitize user-supplied host to prevent SSRF via arbitrary schemes/paths.
+    const safeHost = this.sanitizeHost(host);
+
+    const baseURL = `${useHttps ? 'https' : 'http'}://${safeHost}${
+      port !== (useHttps ? 443 : 80) ? ':' + port : ''
+    }`;
     
     return axios.create({
       baseURL,


### PR DESCRIPTION
Potential fix for [https://github.com/TheInfamousToTo/PiHoleVault/security/code-scanning/33](https://github.com/TheInfamousToTo/PiHoleVault/security/code-scanning/33)

General approach: validate and constrain the user-provided `host` (and `webPort`) before using them to build `baseURL`. At minimum, ensure `host` is a bare hostname or IP, does not include a protocol or path, and is not an internal or link-local address if that’s not explicitly desired. The safest pattern is to: (1) parse/normalize `host`, (2) reject values that are clearly malformed or dangerous (contain `/`, `@`, protocol prefixes, etc.), (3) optionally enforce an allow‑list or restrict to RFC1918 ranges / specific domains, and (4) bound `webPort` to a sensible range. This prevents attackers from turning the application into a blind HTTP client to arbitrary endpoints while preserving existing functionality for legitimate Pi‑hole instances.

Best single change here without redesigning the API: add a small sanitizer inside `PiHoleWebService.createApiClient` that (a) strips or rejects protocol prefixes, (b) rejects hosts containing path segments, query, or fragments, and (c) optionally restricts to a safe set of characters/length. Because we must not assume additional project structure, we’ll implement this as a private helper inside `PiHoleWebService` and use only core Node modules (`url` is not needed if we keep the logic simple). We’ll then use the sanitized host for both the “full URL” case and the simple host:port case, rather than trusting a user-supplied full URL.

Concretely, in `backend/services/PiHoleWebService.js`:

- Add a helper method `sanitizeHost(host)` inside the `PiHoleWebService` class, above `createApiClient`. It will:
  - Trim whitespace.
  - If it starts with `http://` or `https://`, strip the scheme and everything after the first `/` (reject if there is any path/query/fragment).
  - Reject any remaining host containing `/`, `\`, `?`, `#`, or whitespace.
  - Optionally enforce a whitelist of characters via regex (letters, digits, dots, hyphens, colons for IPv6 if you want to be more permissive).
  - Throw an error if invalid.
- Update `createApiClient` to always pass `host` through `sanitizeHost` and to stop accepting arbitrary full URLs; instead, it will always construct `baseURL` from `useHttps`, sanitized host, and `port`. This removes the ability for a caller to smuggle protocol, path, query, etc., in `host`.
- Leave the rest of the logic intact so current Pi‑hole connectivity still works; callers still pass `host`, `webPort`, and `useHttps` in the same way.

No changes are required in `backend/routes/pihole.js` for data flow; we’re constraining the sink in the service layer where the HTTP client is created.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
