### PR TITLE
Potential fix for code scanning alert no. 38: Disabling certificate validation

### DIFF
--- a/backend/services/PiHoleWebService.js
+++ b/backend/services/PiHoleWebService.js
@@ -51,13 +51,13 @@ class PiHoleWebService {
     const baseURL = `${useHttps ? 'https' : 'http'}://${safeHost}${
       port !== (useHttps ? 443 : 80) ? ':' + port : ''
     }`;
-    
+
+    const httpsAgent = useHttps ? new https.Agent() : undefined;
+
     return axios.create({
       baseURL,
       timeout: 30000,
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: false
-      }),
+      ...(httpsAgent && { httpsAgent }),
       headers: {
         'User-Agent': 'PiHoleVault/1.0'
       }


### PR DESCRIPTION
Potential fix for [https://github.com/TheInfamousToTo/PiHoleVault/security/code-scanning/38](https://github.com/TheInfamousToTo/PiHoleVault/security/code-scanning/38)

To fix the problem, we should stop disabling TLS certificate validation and let Node’s default behavior verify server certificates against the system trust store. This means removing `rejectUnauthorized: false` and only customizing the `https.Agent` when strictly necessary (for example, when a trusted custom CA is configured), and even then keeping `rejectUnauthorized: true`.

The single best fix, without changing functionality more than necessary, is:

- Do not create an `https.Agent` with `rejectUnauthorized: false` by default.
- When `useHttps` is `false`, we don’t need an `https.Agent` at all.
- When `useHttps` is `true`, either:
  - Rely on the default `https.Agent` by omitting `httpsAgent` entirely, or
  - If in the wider codebase there is support for custom CA certificates, we could create an `https.Agent` with that CA while keeping `rejectUnauthorized` at its default (`true`). Because we are not shown such configuration here, we will choose the safe/default path: only set `httpsAgent` when `useHttps` is true, and in that case, do not override `rejectUnauthorized`.

Concretely in `backend/services/PiHoleWebService.js`, inside `createApiClient`:

- Compute the `httpsAgent` based on `useHttps`:
  - `const httpsAgent = useHttps ? new https.Agent() : undefined;`
- Pass this `httpsAgent` into `axios.create`, but only when defined.
- Remove `rejectUnauthorized: false` entirely.

This keeps the public interface of `createApiClient` unchanged while restoring proper certificate validation for HTTPS connections.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
